### PR TITLE
Differentiate both male and female 'pronouns' for guild owner

### DIFF
--- a/default/commands-discord.yml
+++ b/default/commands-discord.yml
@@ -104,6 +104,7 @@ commands:
       verificationLevel: "Nível de Verificação"
       features: "Recursos Exclusivos"
       owner: "Dono"
+      owner_female: "Dona"
       region: "Região"
       textChannels: "Texto"
       createdAt: "Criado em"

--- a/default/commands-discord.yml
+++ b/default/commands-discord.yml
@@ -104,7 +104,7 @@ commands:
       verificationLevel: "Nível de Verificação"
       features: "Recursos Exclusivos"
       owner: "Dono"
-      owner_female: "Dona"
+      ownerFemale: "Dona"
       region: "Região"
       textChannels: "Texto"
       createdAt: "Criado em"


### PR DESCRIPTION
In languages like Portuguese, "owner" has two variants for both genders: "dono" and "dona".
This PR is made to differentiate both variants of the word "owner".

To be merged with LorittaBot/Loritta#2302